### PR TITLE
ci: add gate job for non-code PR mergeability

### DIFF
--- a/.github/workflows/test-deploy-dev.yml
+++ b/.github/workflows/test-deploy-dev.yml
@@ -91,3 +91,30 @@ jobs:
         run: railway up --project=${{ vars.RAILWAY_PROJECT_ID }} --service=${{ vars.RAILWAY_SERVICE_NAME }} --environment=development
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+  # Gate job: single required status check for branch protection.
+  # Always runs so non-code PRs (where tests/deploy are skipped) can still merge.
+  # In branch protection settings, replace individual job checks with this one.
+  gate:
+    needs: [check-changes, tests, deploy]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        env:
+          HAS_V2_CHANGES: ${{ needs.check-changes.outputs.has-v2-changes }}
+          TESTS_RESULT: ${{ needs.tests.result }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+        run: |
+          # If v2 changes were detected, tests and deploy must have succeeded
+          if [ "$HAS_V2_CHANGES" == "true" ]; then
+            if [ "$TESTS_RESULT" != "success" ]; then
+              echo "Tests failed or were cancelled"
+              exit 1
+            fi
+            if [ "$DEPLOY_RESULT" != "success" ]; then
+              echo "Deploy failed or was cancelled"
+              exit 1
+            fi
+          fi
+          echo "All required checks passed"


### PR DESCRIPTION
## Summary
- Adds a `gate` job to the CI workflow that **always runs**, even when `tests` and `deploy` are skipped for non-code PRs
- When v2/workflow changes are present, `gate` verifies both `tests` and `deploy` succeeded before passing
- When no code changes exist, `gate` passes immediately, unblocking the PR
- Closes #86

## Required manual step
After merging, update **branch protection settings** for `main`:
1. Settings → Branches → `main` protection rule
2. Remove `tests` and `deploy` from required status checks
3. Add `gate` as the required status check

## Test plan
- [ ] Open a PR with only non-code changes (e.g., docs) — verify `gate` passes and PR is mergeable
- [ ] Open a PR with v2/ code changes — verify `tests`, `deploy`, and `gate` all run; `gate` fails if either upstream job fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)