### PR TITLE
fix(ci): use GitHub Deployments API for staging gate in prod deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -56,49 +56,48 @@ jobs:
           fi
           echo "Confirmed commit $DEPLOY_SHA is on main."
 
-      - name: Verify staging deployment on Railway
+      - name: Verify staging deployment via GitHub Deployments
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
-          RAILWAY_STAGING_ENV_ID: ${{ vars.RAILWAY_STAGING_ENVIRONMENT_ID }}
-          RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+          GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ steps.resolve.outputs.sha }}
+          STAGING_ENV: ${{ vars.RAILWAY_STAGING_DEPLOY_ENV_NAME }}
         run: |
-          echo "Checking Railway staging for successful deployment of commit $COMMIT_SHA..."
+          echo "Checking GitHub Deployments for successful staging deployment of commit $COMMIT_SHA..."
 
-          # Query Railway GraphQL API for deployments matching this commit in staging
-          # serviceId is required — without it the API returns null for edges
-          RESPONSE=$(curl -s -X POST \
-            -H "Authorization: Bearer $RAILWAY_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"query\": \"query { deployments(input: { projectId: \\\"$RAILWAY_PROJECT_ID\\\", environmentId: \\\"$RAILWAY_STAGING_ENV_ID\\\", serviceId: \\\"$RAILWAY_SERVICE_ID\\\" }) { edges { node { id status meta } } } }\"
-            }" \
-            "https://backboard.railway.app/graphql/v2")
+          # Query GitHub Deployments API for this commit in the staging environment
+          DEPLOYMENTS=$(gh api "repos/${{ github.repository }}/deployments?sha=$COMMIT_SHA&environment=$STAGING_ENV&per_page=10" 2>&1)
 
-          # Verify the API returned valid data before querying
-          ERRORS=$(echo "$RESPONSE" | jq -r '.errors // [] | length')
-          if [ "$ERRORS" != "0" ]; then
-            echo "::error::Railway API returned errors:"
-            echo "$RESPONSE" | jq '.errors' 2>/dev/null || echo "$RESPONSE"
+          if [ $? -ne 0 ]; then
+            echo "::error::Failed to query GitHub Deployments API."
+            echo "$DEPLOYMENTS"
             exit 1
           fi
 
-          # Check if any deployment matches this commit SHA and has SUCCESS status
-          # Use '// []' fallback to handle null edges gracefully
-          MATCH=$(echo "$RESPONSE" | jq -r \
-            --arg sha "$COMMIT_SHA" \
-            '[(.data.deployments.edges // [])[] | .node | select((.meta.commitHash // .meta.commit_hash // "") == $sha and .status == "SUCCESS")] | length')
-
-          if [ "$MATCH" = "0" ] || [ "$MATCH" = "null" ] || [ -z "$MATCH" ]; then
-            echo "::error::No successful staging deployment found on Railway for commit $COMMIT_SHA."
+          COUNT=$(echo "$DEPLOYMENTS" | jq 'length')
+          if [ "$COUNT" = "0" ]; then
+            echo "::error::No staging deployment found for commit $COMMIT_SHA in environment '$STAGING_ENV'."
             echo "::error::Railway must auto-deploy this commit to staging before it can be promoted to production."
-            echo "API response for debugging:"
-            echo "$RESPONSE" | jq '.' 2>/dev/null || echo "$RESPONSE"
             exit 1
           fi
 
-          echo "Found $MATCH successful staging deployment(s) for this commit. Proceeding."
+          # Check if any deployment has a successful status
+          FOUND_SUCCESS=false
+          for DEPLOY_ID in $(echo "$DEPLOYMENTS" | jq -r '.[].id'); do
+            STATE=$(gh api "repos/${{ github.repository }}/deployments/$DEPLOY_ID/statuses" --jq '.[0].state')
+            echo "Deployment $DEPLOY_ID status: $STATE"
+            if [ "$STATE" = "success" ]; then
+              FOUND_SUCCESS=true
+              break
+            fi
+          done
+
+          if [ "$FOUND_SUCCESS" != "true" ]; then
+            echo "::error::No successful staging deployment found for commit $COMMIT_SHA."
+            echo "::error::Latest deployment status was: $STATE"
+            exit 1
+          fi
+
+          echo "Confirmed successful staging deployment for commit $COMMIT_SHA. Proceeding."
 
   deploy-production:
     needs: preflight


### PR DESCRIPTION
## Summary
- Replace Railway GraphQL API with GitHub Deployments API for the staging gate check in the production deploy workflow
- Railway automatically creates GitHub Deployment records, so we query those instead of Railway's unstable GraphQL API
- No extra secrets needed — uses the built-in `GITHUB_TOKEN` which has read access to deployments
- Removes dependency on `RAILWAY_STAGING_ENVIRONMENT_ID` and `RAILWAY_SERVICE_ID` variables

## Prerequisites
- Add `RAILWAY_STAGING_DEPLOY_ENV_NAME` repository variable (value: `Sing Portfolio / staging`)
- Can remove `RAILWAY_STAGING_ENVIRONMENT_ID` and `RAILWAY_SERVICE_ID` variables (no longer used)

## Test plan
- [ ] Add `RAILWAY_STAGING_DEPLOY_ENV_NAME` variable to the repository
- [ ] Trigger the production deploy workflow and verify the preflight step passes
- [ ] Verify it correctly detects successful staging deployments via GitHub Deployments API
- [ ] Verify it correctly blocks when no staging deployment exists for the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)